### PR TITLE
Fix windows documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,21 @@ To save time on subsequent incremental builds, you may simply run `make` inside 
 
 ### For Windows
 
-Install the tools needed to build using the Chocolatey package manager:
+Run the following within an ADMIN Powershell window in order to set up the Chocolatey package manager:
 
 ```powershell
-choco install git -y
-choco install cmake -y --installargs 'ADD_CMAKE_TO_PATH=System'
-choco install ninja -y
-choco install gcc-arm-embedded -y
+Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 ```
-Build the example application:
+
+Then, also in an ADMIN Powershell window, allow the execution of local scripts & install the toolchain using Choco.
 ```powershell
-mkdir build
-cd build/
-cmake .. -DCMAKE_TOOLCHAIN_FILE="../arm_gcc_m2351.cmake" -G "Ninja" ; cmake . ; ninja
+Set-ExecutionPolicy RemoteSigned
+.\install-toolchain.ps1
+```
+
+Finally, set up the build directory & compile your binaries:
+```powershell
+.\configure-build.ps1
 ```
 
 On subsequent builds, you only need to run `ninja` inside your build directory.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Set-ExecutionPolicy RemoteSigned
 .\install-toolchain.ps1
 ```
 
-Finally, set up the build directory & compile your binaries:
+Finally, set up the build directory & compile your binaries. This can be done outside of an ADMIN shell.
 ```powershell
 .\configure-build.ps1
 ```

--- a/README.md
+++ b/README.md
@@ -7,16 +7,33 @@ This repository shows an example of how you can put together a KNX-IOT applicati
 In order to build this repository, you need CMake version 3.18 or greater, as well as a recent ARM GCC compiler. See the [Development Environment Setup guide](https://github.com/Cascoda/cascoda-sdk/blob/master/docs/guides/development-setup.md) for detailed instructions on how to set this up. 
 
 ## Build Instructions
+### For Linux
 ```bash
 mkdir build
 cd build/
-# You may get an error concernining a missing "/include" path. 
-# Please ignore it, the following 'make' command will
-# succeed regardless
 cmake .. -DCMAKE_TOOLCHAIN_FILE=../arm_gcc_m2351.cmake || make
 ```
 
 To save time on subsequent incremental builds, you may simply run `make` inside your build directory.
+
+### For Windows
+
+Install the tools needed to build using the Chocolatey package manager:
+
+```powershell
+choco install git -y
+choco install cmake -y --installargs 'ADD_CMAKE_TO_PATH=System'
+choco install ninja -y
+choco install gcc-arm-embedded -y
+```
+Build the example application:
+```powershell
+mkdir build
+cd build/
+cmake .. -DCMAKE_TOOLCHAIN_FILE="../arm_gcc_m2351.cmake" -G "Ninja" ; cmake . ; ninja
+```
+
+On subsequent builds, you only need to run `ninja` inside your build directory.
 
 ## Example Binaries
 

--- a/configure-build.ps1
+++ b/configure-build.ps1
@@ -1,0 +1,4 @@
+mkdir build
+cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE="../arm_gcc_m2351.cmake" -G "Ninja" ; cmake .
+ninja

--- a/install-toolchain.ps1
+++ b/install-toolchain.ps1
@@ -1,0 +1,3 @@
+# Must run in ADMIN powershell
+choco install ninja gcc-arm-embedded -y
+choco install cmake -y --installargs 'ADD_CMAKE_TO_PATH=System'


### PR DESCRIPTION
The `cmake .` in the line that starts the build is necessary to work around the include dir issue that happens upon the first configure. Subsequent calls to `ninja` work just fine. 